### PR TITLE
feat: use apply

### DIFF
--- a/demos/benchmark.ts
+++ b/demos/benchmark.ts
@@ -139,15 +139,17 @@ const run = async (
 };
 
 // Prepare arguments for benchmarking
-const tsWrapper = wrapper((fn, ...args: any[]) => {
-  return fn(...args);
+const tsWrapper = wrapper(function (fn, ...args: any[]) {
+  // @ts-ignore TS2683
+  return fn.call(this, ...args);
 });
 
 export const manWrapper = <FArgs extends any[], FReturn>(
   fn: (...args: FArgs) => FReturn
 ) => {
   return function newFn(...args: Parameters<typeof fn>) {
-    const result = fn(...args);
+    // @ts-ignore TS2683
+    const result = fn.call(this, ...args);
     return result;
   };
 };

--- a/src/common/als.ts
+++ b/src/common/als.ts
@@ -1,12 +1,15 @@
 import { AsyncLocalStorage } from "async_hooks";
 
-export function als<T, FArgs extends any[]>(
+export function als<T, IArgs extends any[]>(
   storage: AsyncLocalStorage<T>,
-  init: (...args: FArgs) => T
+  init: (...args: IArgs) => T
 ) {
-  return <FFArgs extends FArgs, FReturn>(fn: (...args: FFArgs) => FReturn) => {
-    return function newFn(...args: Parameters<typeof fn>) {
-      const result = storage.run(init(...args), fn, ...args);
+  return function <FArgs extends IArgs, FReturn>(
+    fn: (...args: FArgs) => FReturn
+  ) {
+    return function (...args: Parameters<typeof fn>) {
+      // @ts-ignore TS2683
+      const result = storage.run(init(...args), fn.bind(this), ...args);
       return result;
     };
   };

--- a/src/common/debounce.ts
+++ b/src/common/debounce.ts
@@ -4,15 +4,15 @@ export function debounce(wait = 300, leading = false) {
     function (...args: Parameters<typeof fn>) {
       return new Promise<ReturnType<typeof fn>>(
         async (resolve: any, reject: any) => {
-          // @ts-ignore TS2683
-          const next = () => fn.apply(this, args);
           clearTimeout(timeout);
 
-          leading && !timeout && resolve(await next());
+          // @ts-ignore TS2683
+          leading && !timeout && resolve(await fn.apply(this, args));
           timeout = setTimeout(async () => {
             try {
               timeout = null;
-              !leading && resolve(next());
+              // @ts-ignore TS2683
+              !leading && resolve(await fn.apply(this, args));
             } catch (e) {
               reject(e);
             }

--- a/src/common/debounce.ts
+++ b/src/common/debounce.ts
@@ -1,19 +1,23 @@
 export function debounce(wait = 300, leading = false) {
   let timeout: any;
   return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) =>
-    (...args: Parameters<typeof fn>) => {
-      return new Promise<ReturnType<typeof fn>>((resolve, reject) => {
-        clearTimeout(timeout);
+    function (...args: Parameters<typeof fn>) {
+      return new Promise<ReturnType<typeof fn>>(
+        async (resolve: any, reject: any) => {
+          // @ts-ignore TS2683
+          const next = () => fn.apply(this, args);
+          clearTimeout(timeout);
 
-        leading && !timeout && resolve(fn(...args));
-        timeout = setTimeout(async () => {
-          try {
-            timeout = null;
-            !leading && resolve(await fn(...args));
-          } catch (e) {
-            reject(e);
-          }
-        }, wait);
-      });
+          leading && !timeout && resolve(await next());
+          timeout = setTimeout(async () => {
+            try {
+              timeout = null;
+              !leading && resolve(next());
+            } catch (e) {
+              reject(e);
+            }
+          }, wait);
+        }
+      );
     };
 }

--- a/src/common/delay.ts
+++ b/src/common/delay.ts
@@ -1,10 +1,14 @@
 export function delay(wait: number) {
-  return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) =>
-    (...args: Parameters<typeof fn>) => {
+  return function <FArgs extends any[], FReturn>(
+    fn: (...args: FArgs) => FReturn
+  ) {
+    return function (...args: Parameters<typeof fn>) {
       return new Promise<ReturnType<typeof fn>>((resolve) => {
         setTimeout(() => {
-          resolve(fn(...args));
+          // @ts-ignore TS2683
+          resolve(fn.apply(this, args));
         }, wait);
       });
     };
+  };
 }

--- a/src/common/intercept.ts
+++ b/src/common/intercept.ts
@@ -1,7 +1,12 @@
 export function intercept<F extends Function>(interceptor: F) {
-  return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) =>
-    (...args: Parameters<typeof fn>) => {
-      interceptor(...args);
-      return fn(...args);
+  return function <FArgs extends any[], FReturn>(
+    fn: (...args: FArgs) => FReturn
+  ) {
+    return function (...args: Parameters<typeof fn>) {
+      // @ts-ignore TS2683
+      interceptor.apply(this, args);
+      // @ts-ignore TS2683
+      return fn.apply(this, args);
     };
+  };
 }

--- a/src/common/intercept.ts
+++ b/src/common/intercept.ts
@@ -1,10 +1,12 @@
-export function intercept<F extends Function>(interceptor: F) {
-  return function <FArgs extends any[], FReturn>(
+export function intercept<IArgs extends any[], IReturn>(
+  interceptor: (...args: IArgs) => IReturn
+) {
+  return function <FArgs extends IArgs, FReturn>(
     fn: (...args: FArgs) => FReturn
   ) {
-    return function (...args: Parameters<typeof fn>) {
+    return async function (...args: Parameters<typeof fn>) {
       // @ts-ignore TS2683
-      interceptor.apply(this, args);
+      await interceptor.apply(this, args);
       // @ts-ignore TS2683
       return fn.apply(this, args);
     };

--- a/src/common/memoize.ts
+++ b/src/common/memoize.ts
@@ -3,10 +3,11 @@ export function memoize<H extends (...args: any[]) => string | number | symbol>(
   cache = Object.create(null)
 ) {
   return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) =>
-    (...args: Parameters<typeof fn>) => {
+    function (...args: Parameters<typeof fn>) {
       const key = hash(...args);
       if (!(key in cache)) {
-        cache[key] = fn(...args);
+        // @ts-ignore TS2683
+        cache[key] = fn.apply(this, args);
       }
       return cache[key] as ReturnType<typeof fn>;
     };

--- a/src/common/memoize.ts
+++ b/src/common/memoize.ts
@@ -1,10 +1,11 @@
-export function memoize<H extends (...args: any[]) => string | number | symbol>(
+export function memoize<H extends (...args: any[]) => any>(
   hash: H,
   cache = Object.create(null)
 ) {
   return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) =>
     function (...args: Parameters<typeof fn>) {
-      const key = hash(...args);
+      // @ts-ignore TS2683
+      const key = hash.apply(this, args);
       if (!(key in cache)) {
         // @ts-ignore TS2683
         cache[key] = fn.apply(this, args);

--- a/src/common/once.ts
+++ b/src/common/once.ts
@@ -2,10 +2,11 @@ export const once = <FArgs extends any[], FReturn>(
   fn: (...args: FArgs) => FReturn
 ) => {
   let executed = false;
-  return (...args: Parameters<typeof fn>) => {
+  return function (...args: Parameters<typeof fn>) {
     if (!executed) {
       executed = true;
-      return fn(...args);
+      // @ts-ignore TS2683
+      return fn.apply(this, args);
     }
   };
 };

--- a/src/common/repeat.ts
+++ b/src/common/repeat.ts
@@ -1,13 +1,14 @@
 export const repeat = (times: number, delay = 500) => {
   return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) =>
-    (...args: Parameters<typeof fn>) => {
+    function (...args: Parameters<typeof fn>) {
       let numTimes = 0;
       const interval = setInterval(() => {
         numTimes++;
         if (numTimes >= times) {
           clearInterval(interval);
         }
-        fn(...args);
+        // @ts-ignore TS2683
+        fn.apply(this, args);
       }, delay);
     };
 };

--- a/src/common/retry.ts
+++ b/src/common/retry.ts
@@ -1,12 +1,13 @@
 export const retry = (times: number, delay = 500) => {
   return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) =>
-    (...args: Parameters<typeof fn>) => {
+    function (...args: Parameters<typeof fn>) {
       let attempts = 0;
       return new Promise<ReturnType<typeof fn>>((resolve, reject) => {
         const interval = setInterval(() => {
           attempts += 1;
           try {
-            const result = fn(...args);
+            // @ts-ignore TS2683
+            const result = fn.apply(this, args);
             resolve(result);
 
             if (attempts <= times) {

--- a/src/common/throttle.ts
+++ b/src/common/throttle.ts
@@ -1,12 +1,13 @@
 export function throttle(delay: number) {
   return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) => {
     let wait = false;
-    return (...args: Parameters<typeof fn>) => {
+    return function (...args: Parameters<typeof fn>) {
       if (wait) {
         return;
       }
 
-      const result = fn(...args);
+      // @ts-ignore TS2683
+      const result = fn.apply(this, args);
       wait = true;
 
       setTimeout(() => {

--- a/src/common/trace.ts
+++ b/src/common/trace.ts
@@ -1,9 +1,11 @@
-export const trace =
-  <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) =>
-  (...args: Parameters<typeof fn>) => {
+export const trace = <FArgs extends any[], FReturn>(
+  fn: (...args: FArgs) => FReturn
+) =>
+  function (...args: Parameters<typeof fn>) {
     const tag = `${fn.name}(${args}) | duration`;
     console.time(tag);
-    const result = fn(...args);
+    // @ts-ignore TS2683
+    const result = fn.apply(this, args);
     console.timeEnd(tag);
     return result;
   };

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -2,8 +2,13 @@ export default function wrapper<CArgs extends any[], CReturn>(
   cb: (fn: Fn, ...args: CArgs) => CReturn
 ) {
   return <FArgs extends CArgs, FReturn>(func: Func<FArgs, FReturn>) => {
-    return (...args: Parameters<typeof func>) => {
-      return cb(func as Parameters<typeof cb>[0], ...(args as any)) as Replace<
+    return function (...args: Parameters<typeof func>) {
+      return cb.call(
+        // @ts-ignore TS2683
+        this,
+        func as Parameters<typeof cb>[0],
+        ...(args as CArgs)
+      ) as Replace<
         CReturn,
         FnReturnType,
         ReturnType<typeof func>,


### PR DESCRIPTION
This PR updates all wrappers to use `.apply` to invoke functions instead of regular function call in order to maintain the correct reference to `this` in returned functions.