### PR TITLE
test: add als tests

### DIFF
--- a/src/common/als.ts
+++ b/src/common/als.ts
@@ -7,10 +7,19 @@ export function als<T, IArgs extends any[]>(
   return function <FArgs extends IArgs, FReturn>(
     fn: (...args: FArgs) => FReturn
   ) {
-    return function (...args: Parameters<typeof fn>) {
+    function newFn(...args: Parameters<typeof fn>) {
       // @ts-ignore TS2683
       const result = storage.run(init(...args), fn.bind(this), ...args);
       return result;
-    };
+    }
+
+    // Copy properties to new function
+    Object.entries(Object.getOwnPropertyDescriptors(fn)).forEach(
+      ([prop, descriptor]) => {
+        Object.defineProperty(newFn, prop, descriptor);
+      }
+    );
+
+    return newFn;
   };
 }

--- a/test/als.test.ts
+++ b/test/als.test.ts
@@ -1,0 +1,90 @@
+import { AsyncLocalStorage } from "async_hooks";
+import test from "ava";
+import { als } from "../src";
+
+test("maintains reference to this", async (t) => {
+  const storage = new AsyncLocalStorage<ReturnType<typeof init>>();
+  const init = (x: number) => ({
+    x,
+  });
+
+  const x = () => {
+    return storage.getStore()!.x;
+  };
+
+  const data = {
+    val: 1,
+    incBy: als(
+      storage,
+      init
+    )(function (this: any) {
+      return this.val + x();
+    }),
+  };
+
+  t.is(data.incBy(2), 3);
+});
+
+test("maintains function properties", async (t) => {
+  let val = 0;
+
+  const init = (..._args: any[]) => -1;
+  const storage = new AsyncLocalStorage<number>();
+
+  function incBy(this: any, num: number, _dummyArg?: any) {
+    val += num;
+    return num;
+  }
+
+  incBy.prototype.foo = "bar";
+
+  const incByWithAls = als(storage, init)(incBy);
+
+  incByWithAls(10);
+
+  t.is(val, 10);
+  t.is(incByWithAls.name, "incBy");
+  t.is(incByWithAls.length, 2);
+  t.is(incByWithAls.prototype.foo, "bar");
+});
+
+test("executes function in async local context", (t) => {
+  const init = (..._args: any[]) => -1;
+  const storage = new AsyncLocalStorage<number>();
+
+  let executed = false;
+
+  const exec = (x: number) => {
+    executed = true;
+    t.is(storage.getStore(), -1);
+    return x;
+  };
+
+  const execWithAls = als(storage, init)(exec);
+
+  t.is(execWithAls(1), 1);
+  t.true(executed);
+});
+
+test("executes with correct storage at nested levels", (t) => {
+  const init = (..._args: any[]) => -1;
+  const init2 = (..._args: any[]) => -2;
+
+  const storage = new AsyncLocalStorage<number>();
+
+  const withAls = als(storage, init);
+  const withAls2 = als(storage, init2);
+
+  const execWithAls = withAls2((x: number) => {
+    t.is(storage.getStore(), -2);
+
+    const inner = withAls((x: number) => {
+      t.is(storage.getStore(), -1);
+      return x;
+    });
+
+    return inner(x);
+  });
+
+  t.is(execWithAls(1), 1);
+});


### PR DESCRIPTION
This PR adds tests for the async local storage wrapper plus updates the implementation to ensure that it maintains reference to the wrapped function's properties for potential telemetary/tooling purposes.

References:
- https://trackjs.com/blog/how-to-wrap-javascript-functions/#code-543