### PR TITLE
test: add repeat tests

### DIFF
--- a/src/common/repeat.ts
+++ b/src/common/repeat.ts
@@ -17,6 +17,12 @@ export const repeat = (times: number, delay = 0) => {
       }
     }
 
+    // Copy properties to new function
+    Object.entries(Object.getOwnPropertyDescriptors(fn)).forEach(
+      ([prop, descriptor]) => {
+        Object.defineProperty(newFn, prop, descriptor);
+      }
+    );
     return newFn;
   };
 };

--- a/src/common/repeat.ts
+++ b/src/common/repeat.ts
@@ -1,14 +1,22 @@
-export const repeat = (times: number, delay = 500) => {
-  return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) =>
-    function (...args: Parameters<typeof fn>) {
-      let numTimes = 0;
-      const interval = setInterval(() => {
-        numTimes++;
-        if (numTimes >= times) {
-          clearInterval(interval);
+import { sleep } from "../sleep";
+
+export const repeat = (times: number, delay = 0) => {
+  return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) => {
+    async function newFn(...args: Parameters<typeof fn>) {
+      for (let i = 0; i < times; i++) {
+        let result = undefined;
+
+        try {
+          // @ts-ignore TS2683
+          result = await fn.apply(this, args);
+        } catch (e) {
+          console.error(e);
         }
-        // @ts-ignore TS2683
-        fn.apply(this, args);
-      }, delay);
-    };
+
+        await sleep(delay);
+      }
+    }
+
+    return newFn;
+  };
 };

--- a/src/common/repeat.ts
+++ b/src/common/repeat.ts
@@ -4,11 +4,9 @@ export const repeat = (times: number, delay = 0) => {
   return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) => {
     async function newFn(...args: Parameters<typeof fn>) {
       for (let i = 0; i < times; i++) {
-        let result = undefined;
-
         try {
           // @ts-ignore TS2683
-          result = await fn.apply(this, args);
+          await fn.apply(this, args);
         } catch (e) {
           console.error(e);
         }

--- a/src/sleep.ts
+++ b/src/sleep.ts
@@ -1,0 +1,5 @@
+export async function sleep(time: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, time);
+  });
+}

--- a/test/repeat.test.ts
+++ b/test/repeat.test.ts
@@ -1,0 +1,59 @@
+import test from "ava";
+import { repeat } from "../src";
+
+test("maintains reference to this", async (t) => {
+  const data = {
+    val: 0,
+    repeatedInc: repeat(3)(function (this: any) {
+      return ++this.val;
+    }),
+  };
+
+  await data.repeatedInc();
+
+  t.is(data.val, 3);
+});
+
+test("maintains function properties", async (t) => {
+  let val = 0;
+
+  function incBy(this: any, num: number, _dummyArg?: any) {
+    val += num;
+    return num;
+  }
+
+  incBy.prototype.foo = "bar";
+
+  const repeatedIncBy = repeat(3)(incBy);
+
+  await repeatedIncBy(10);
+
+  t.is(val, 30);
+  t.is(repeatedIncBy.name, "incBy");
+  t.is(repeatedIncBy.length, 2);
+  t.is(repeatedIncBy.prototype.foo, "bar");
+});
+
+test("executes repeatedly", async (t) => {
+  let currTime: number, prevTime: number;
+
+  let val = 0;
+
+  const repeatedInc = repeat(
+    3,
+    200
+  )(() => {
+    [currTime, prevTime] = [performance.now(), currTime];
+
+    if (prevTime) {
+      const duration = currTime - prevTime;
+      t.assert(Math.round(duration / 10) * 10 >= 200);
+    }
+
+    return ++val;
+  });
+
+  await repeatedInc();
+
+  t.is(val, 3);
+});


### PR DESCRIPTION
This PR adds tests for repeat, updates its implementation to use a for-loop over the interval approach to simplify over the promise approach.