### PR TITLE
test: add retry tests

### DIFF
--- a/src/common/retry.ts
+++ b/src/common/retry.ts
@@ -17,6 +17,13 @@ export const retry = (times: number, delay = 0) => {
       }
     }
 
+    // Copy properties to new function
+    Object.entries(Object.getOwnPropertyDescriptors(fn)).forEach(
+      ([prop, descriptor]) => {
+        Object.defineProperty(newFn, prop, descriptor);
+      }
+    );
+
     return newFn;
   };
 };

--- a/src/common/retry.ts
+++ b/src/common/retry.ts
@@ -1,25 +1,22 @@
-export const retry = (times: number, delay = 500) => {
-  return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) =>
-    function (...args: Parameters<typeof fn>) {
-      let attempts = 0;
-      return new Promise<ReturnType<typeof fn>>((resolve, reject) => {
-        const interval = setInterval(() => {
-          attempts += 1;
-          try {
-            // @ts-ignore TS2683
-            const result = fn.apply(this, args);
-            resolve(result);
+import { sleep } from "../sleep";
 
-            if (attempts <= times) {
-              clearInterval(interval);
-            }
-          } catch (e) {
-            if (attempts >= times) {
-              reject(e);
-              clearInterval(interval);
-            }
+export const retry = (times: number, delay = 0) => {
+  return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) => {
+    async function newFn(...args: Parameters<typeof fn>) {
+      for (let attempt = 1; attempt <= times; attempt++) {
+        try {
+          // @ts-ignore TS2683
+          const result = await fn.apply(this, args);
+          return result;
+        } catch (e) {
+          if (attempt >= times) {
+            throw e;
           }
-        }, delay);
-      });
-    };
+          await sleep(delay);
+        }
+      }
+    }
+
+    return newFn;
+  };
 };

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,0 +1,122 @@
+import test from "ava";
+import { retry } from "../src";
+
+test("maintains reference to this", async (t) => {
+  const data = {
+    val: 0,
+    retryedInc: retry(3)(function (this: any) {
+      return ++this.val;
+    }),
+  };
+
+  await data.retryedInc();
+
+  t.is(data.val, 1);
+});
+
+test("maintains function properties", async (t) => {
+  let val = 0;
+
+  function incBy(this: any, num: number, _dummyArg?: any) {
+    val += num;
+    return num;
+  }
+
+  incBy.prototype.foo = "bar";
+
+  const retryIncBy = retry(1)(incBy);
+
+  await retryIncBy(10);
+
+  t.is(val, 10);
+  t.is(retryIncBy.name, "incBy");
+  t.is(retryIncBy.length, 2);
+  t.is(retryIncBy.prototype.foo, "bar");
+});
+
+test("executes when no errors", async (t) => {
+  let val = 0;
+
+  const retryedInc = retry(3)(() => {
+    return ++val;
+  });
+
+  await retryedInc();
+
+  t.is(val, 1);
+});
+
+test("retries with delay", async (t) => {
+  let currTime: number, prevTime: number;
+
+  const DELAY = 100;
+  const RETRY_AMOUNT = 3;
+
+  const retryedInc = retry(
+    RETRY_AMOUNT,
+    DELAY
+  )(() => {
+    [currTime, prevTime] = [performance.now(), currTime];
+
+    if (prevTime) {
+      const duration = currTime - prevTime;
+      t.assert(Math.round(duration / 10) * 10 >= DELAY);
+    }
+
+    throw new Error("Error!");
+  });
+
+  await retryedInc().catch(() => {});
+});
+
+test("retries and succeeds", async (t) => {
+  let val = 0;
+
+  const DELAY = 200;
+  const RETRY_AMOUNT = 3;
+
+  let callCount = 0;
+
+  const retryedInc = retry(
+    RETRY_AMOUNT,
+    DELAY
+  )(() => {
+    callCount += 1;
+
+    // Only succeed on final retry
+    if (callCount < 3) {
+      throw new Error("Error!");
+    }
+
+    return ++val;
+  });
+
+  await retryedInc();
+
+  t.is(val, 1);
+  t.is(callCount, 3);
+});
+
+test("retries and fails", async (t) => {
+  let val = 0;
+
+  let callCount = 0;
+
+  const RETRY_AMOUNT = 3;
+
+  const retryedInc = retry(RETRY_AMOUNT)(() => {
+    callCount += 1;
+
+    // Only succeed on final retry
+    if (callCount < RETRY_AMOUNT + 1) {
+      throw new Error("Error!");
+    }
+
+    return ++val;
+  });
+
+  await t.throwsAsync(async () => retryedInc());
+
+  t.is(val, 0);
+  t.is(callCount, 3);
+});


### PR DESCRIPTION
This PR adds tests for the retry wrapper, moves implementation to an iterative approach as well as ensures that it maintains properties from the wrapped function.