### PR TITLE
feat: add keyed debounce

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/demos/debounce.ts
+++ b/demos/debounce.ts
@@ -7,7 +7,7 @@ async function sleep(time: number) {
 }
 
 export async function demo() {
-  const debouncedLog = debounce(500, true)(console.log);
+  const debouncedLog = debounce(500, { leading: true })(console.log);
 
   // BEGIN
   debouncedLog("Hey there!");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-wrappers",
-  "version": "0.0.2-alpha.1",
+  "version": "0.0.2",
   "description": "Transparent, Type-safe wrappers for your Typescript functions",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-wrappers",
-  "version": "0.0.1",
+  "version": "0.0.2-alpha.1",
   "description": "Transparent, Type-safe wrappers for your Typescript functions",
   "main": "dist/index.js",
   "scripts": {

--- a/src/common/debounce.ts
+++ b/src/common/debounce.ts
@@ -1,22 +1,51 @@
-export function debounce(wait = 300, leading = false) {
-  let timeout: any;
-  return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) => {
-    function newFn(...args: Parameters<typeof fn>) {
-      return new Promise<Awaited<ReturnType<typeof fn>>>(
-        async (resolve: any, reject: any) => {
-          clearTimeout(timeout);
+type DebounceOptions<KArgs extends any[]> = {
+  leading?: boolean;
+  keyFn?: (...args: KArgs) => any;
+};
 
-          // @ts-ignore TS2683
-          leading && !timeout && resolve(await fn.apply(this, args));
+export function debounce<KArgs extends any[]>(
+  wait: number,
+  options?: DebounceOptions<KArgs>
+) {
+  const { leading = false, keyFn } = options || {};
+
+  let timeout: any;
+  let timeoutKey: any;
+  let timeoutCache: Record<string, any>;
+
+  if (keyFn) {
+    timeoutCache = {};
+  }
+  return <FArgs extends KArgs, FReturn>(fn: (...args: FArgs) => FReturn) => {
+    function newFn(...args: Parameters<typeof fn>) {
+      if (keyFn) {
+        // @ts-ignore TS2683
+        timeoutKey = keyFn.apply(this, args);
+        timeout = timeoutCache[timeoutKey];
+      }
+      return new Promise<Awaited<ReturnType<typeof fn>>>(
+        (resolve: any, reject: any) => {
+          if (leading && !timeout) {
+            // @ts-ignore TS2683
+            (async () => resolve(await fn.apply(this, args)))();
+          }
+
+          clearTimeout(timeout);
           timeout = setTimeout(async () => {
             try {
               timeout = null;
-              // @ts-ignore TS2683
-              !leading && resolve(await fn.apply(this, args));
+              if (!leading) {
+                // @ts-ignore TS2683
+                resolve(await fn.apply(this, args));
+              }
             } catch (e) {
               reject(e);
             }
           }, wait);
+
+          if (keyFn) {
+            timeoutCache[timeoutKey] = timeout;
+          }
         }
       );
     }


### PR DESCRIPTION
# Overview
This PR adds support for keyed debouncing. It allows for grouping debounces together at a top level.

One immediate use-case I have for this is debouncing the `onChange` handler in an HTTP `<form />` on a per form field basis. This way, all changes to all form fields are debounced separately and no changes are dropped.

TODO
NB: as I type this, possibly wait times could also be dynamic/conditional based on a `waitFn` option.