### PR TITLE
feat: suppress retry errors

### DIFF
--- a/src/common/retry.ts
+++ b/src/common/retry.ts
@@ -1,17 +1,55 @@
 import { sleep } from "../sleep";
+import { Any } from "./types";
 
+/** Implementation of SuppressedError
+ *
+ * Source: https://github.com/microsoft/TypeScript/blob/db3d54ffbc0a805fbdd5104c5a5137d7ca84420a/src/compiler/factory/emitHelpers.ts#L1458
+ * */
+export class SuppressedError extends Error {
+  constructor(error: any, suppressed: any, message: string) {
+    super(message);
+    this.error = error;
+    this.suppressed = suppressed;
+  }
+
+  name = "SuppressedError";
+  error: any;
+  suppressed: any;
+}
+
+/**
+ * Retries a function with the given delay.
+ *
+ * Suppresses errors that occur and throws a suppressed error at the end or
+ * returns the result when it succeeds.
+ * */
 export const retry = (times: number, delay = 0) => {
-  return <FArgs extends any[], FReturn>(fn: (...args: FArgs) => FReturn) => {
-    async function newFn(...args: Parameters<typeof fn>) {
+  return function <Fn extends Any.AsyncFunction>(fn: Fn) {
+    async function newFn(this: any, ...args: Parameters<Fn>) {
+      const ctx: { error?: any; hasError: boolean } = {
+        error: undefined,
+        hasError: false,
+      };
+
       for (let attempt = 1; attempt <= times; attempt++) {
         try {
-          // @ts-ignore TS2683
           const result = await fn.apply(this, args);
           return result;
         } catch (e) {
+          ctx.error = ctx.hasError
+            ? new SuppressedError(
+                e,
+                ctx.error,
+                `An error was suppressed during retry attempt ${attempt}`
+              )
+            : e;
+
+          ctx.hasError = true;
+
           if (attempt >= times) {
-            throw e;
+            throw ctx.error;
           }
+
           await sleep(delay);
         }
       }
@@ -24,6 +62,6 @@ export const retry = (times: number, delay = 0) => {
       }
     );
 
-    return newFn;
+    return newFn as Fn;
   };
 };

--- a/src/common/retry.ts
+++ b/src/common/retry.ts
@@ -5,7 +5,7 @@ import { Any } from "./types";
  *
  * Source: https://github.com/microsoft/TypeScript/blob/db3d54ffbc0a805fbdd5104c5a5137d7ca84420a/src/compiler/factory/emitHelpers.ts#L1458
  * */
-export class SuppressedError extends Error {
+class SuppressedError extends Error {
   constructor(error: any, suppressed: any, message: string) {
     super(message);
     this.error = error;
@@ -15,6 +15,10 @@ export class SuppressedError extends Error {
   name = "SuppressedError";
   error: any;
   suppressed: any;
+}
+
+export class RetryError extends SuppressedError {
+  name = "RetryError";
 }
 
 /**
@@ -37,7 +41,7 @@ export const retry = (times: number, delay = 0) => {
           return result;
         } catch (e) {
           ctx.error = ctx.hasError
-            ? new SuppressedError(
+            ? new RetryError(
                 e,
                 ctx.error,
                 `An error was suppressed during retry attempt ${attempt}`

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -4,6 +4,9 @@ declare namespace Any {
   type Function<I extends Array<unknown> = Array<any>, O = any> = {
     (...args: I): O;
   };
+
+  type AsyncFunction<I extends Array<unknown> = Array<any>, O = any> = {
+    (...args: I): Promise<O>;
+  };
   type Array<T = unknown> = ReadonlyArray<T>;
 }
-

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -92,7 +92,7 @@ test("retries with delay", async (t) => {
   const retryedInc = retry(
     RETRY_AMOUNT,
     DELAY
-  )(() => {
+  )(async () => {
     [currTime, prevTime] = [performance.now(), currTime];
 
     if (prevTime) {
@@ -117,7 +117,7 @@ test("retries and succeeds", async (t) => {
   const retryedInc = retry(
     RETRY_AMOUNT,
     DELAY
-  )(() => {
+  )(async () => {
     callCount += 1;
 
     // Only succeed on final retry
@@ -141,7 +141,7 @@ test("retries and fails", async (t) => {
 
   const RETRY_AMOUNT = 3;
 
-  const retryedInc = retry(RETRY_AMOUNT)(() => {
+  const retryedInc = retry(RETRY_AMOUNT)(async () => {
     callCount += 1;
 
     // Only succeed on final retry

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,5 +1,5 @@
 import test from "ava";
-import { SuppressedError, retry } from "../src";
+import { RetryError, retry } from "../src";
 import { performance } from "perf_hooks";
 
 test("maintains reference to this", async (t) => {
@@ -24,7 +24,7 @@ test("tracks retry errors", async (t) => {
   };
 
   const err = await t.throwsAsync(data.retryedInc.bind(data), {
-    instanceOf: SuppressedError,
+    instanceOf: RetryError,
   });
 
   t.is(err?.message, "An error was suppressed during retry attempt 3");


### PR DESCRIPTION
# Overview
This PR introduces a `RetryError` class that can be used to track errors that occur during a retry. This feature is inspired by the recently added `SuppressedError` to Typescript 5.2 as part of the introduction of `using` keyword in https://github.com/microsoft/TypeScript/pull/54505.

Previously the retry function threw only the last error but following this change, now throws a `RetryError`, with the causing error on the instance's `error` property.

I would have preferred to subclass `SuppressedError` from Typescript vs re-implementing my own equivalent here, however `SuppressedError` does not look to be defined (even after updating to version 5.2). It appears to only available as a global type but not as a concrete class.
