### PR TITLE
feat: support retry with dynamic delay

### DIFF
--- a/demos/retry.ts
+++ b/demos/retry.ts
@@ -5,13 +5,12 @@ export function demo() {
     return Math.ceil(Math.random() * (max + 1));
   }
 
-  async function log(...args: Parameters<typeof console.log>) {
+  async function log(...args: any[]) {
     if (randInt(3) < 3 / 2) {
       // Fail 50% of the time
       throw new Error("Log failed!");
     }
-
-    return console.log(...args);
+    console.log(...args);
   }
 
   const logWithRetry = trace(retry(3)(log));
@@ -23,14 +22,13 @@ export function demoDelayStrategy() {
   const MAX_ATTEMPTS = 2;
   let attempt = 1;
 
-  async function buggyLog(...args: Parameters<typeof console.log>) {
+  const buggyLog = async (...args: any[]) => {
     if (attempt < MAX_ATTEMPTS) {
-      // Fail 50% of the time
       throw new Error(`Log failed! Attempt:${attempt++}`);
     }
     console.log(...args);
     return args.length;
-  }
+  };
 
   const buggyLogWithRetry = trace(
     retry(MAX_ATTEMPTS, delayStrategy.exponential())(buggyLog)
@@ -38,7 +36,7 @@ export function demoDelayStrategy() {
 
   buggyLogWithRetry("Hi from retry (strategy)!")
     .then((r) => {
-      console.log("result:", r);
+      console.log("args.length:", r);
     })
     .catch((e) => console.log(e));
 }

--- a/demos/retry.ts
+++ b/demos/retry.ts
@@ -1,11 +1,11 @@
-import { retry } from "../src";
+import { delayStrategy, retry, trace } from "../src";
 
 export function demo() {
   function randInt(max: number) {
     return Math.ceil(Math.random() * (max + 1));
   }
 
-  function log(...args: Parameters<typeof console.log>) {
+  async function log(...args: Parameters<typeof console.log>) {
     if (randInt(3) < 3 / 2) {
       // Fail 50% of the time
       throw new Error("Log failed!");
@@ -14,9 +14,34 @@ export function demo() {
     return console.log(...args);
   }
 
-  const logWithRetry = retry(3)(log);
+  const logWithRetry = trace(retry(3)(log));
 
   logWithRetry("Hi from retry!").catch((e) => console.log(e));
 }
 
+export function demoDelayStrategy() {
+  const MAX_ATTEMPTS = 2;
+  let attempt = 1;
+
+  async function buggyLog(...args: Parameters<typeof console.log>) {
+    if (attempt < MAX_ATTEMPTS) {
+      // Fail 50% of the time
+      throw new Error(`Log failed! Attempt:${attempt++}`);
+    }
+    console.log(...args);
+    return args.length;
+  }
+
+  const buggyLogWithRetry = trace(
+    retry(MAX_ATTEMPTS, delayStrategy.exponential())(buggyLog)
+  );
+
+  buggyLogWithRetry("Hi from retry (strategy)!")
+    .then((r) => {
+      console.log("result:", r);
+    })
+    .catch((e) => console.log(e));
+}
+
 demo();
+demoDelayStrategy();

--- a/src/common/retry.ts
+++ b/src/common/retry.ts
@@ -21,13 +21,15 @@ export class RetryError extends SuppressedError {
   name = "RetryError";
 }
 
+type RetryDelay = number | ((attempt: number) => number);
+
 /**
  * Retries a function with the given delay.
  *
  * Suppresses errors that occur and throws a suppressed error at the end or
  * returns the result when it succeeds.
  * */
-export const retry = (times: number, delay = 0) => {
+export const retry = (times: number, delay: RetryDelay = 0) => {
   return function <Fn extends Any.AsyncFunction>(fn: Fn) {
     async function newFn(this: any, ...args: Parameters<Fn>) {
       const ctx: { error?: any; hasError: boolean } = {
@@ -54,7 +56,7 @@ export const retry = (times: number, delay = 0) => {
             throw ctx.error;
           }
 
-          await sleep(delay);
+          await sleep(typeof delay === "number" ? delay : delay(attempt - 1));
         }
       }
     }
@@ -68,4 +70,16 @@ export const retry = (times: number, delay = 0) => {
 
     return newFn as Fn;
   };
+};
+
+export const delayStrategy = {
+  /** Source: https://cloud.google.com/memorystore/docs/redis/exponential-backoff */
+  exponential:
+    (base = 2, maxBackoff = 32 * 1000, maxNoise = 1000) =>
+    (n: number) =>
+      Math.min(base ** n * 1000 + Math.random() * maxNoise, maxBackoff),
+  linear:
+    (gradient = 1, intercept = 0) =>
+    (n: number) =>
+      gradient * n * 1000 + intercept,
 };

--- a/src/common/retry.ts
+++ b/src/common/retry.ts
@@ -56,7 +56,7 @@ export const retry = (times: number, delay: RetryDelay = 0) => {
             throw ctx.error;
           }
 
-          await sleep(typeof delay === "number" ? delay : delay(attempt - 1));
+          await sleep(typeof delay === "function" ? delay(attempt - 1) : delay);
         }
       }
     }

--- a/src/common/trace.ts
+++ b/src/common/trace.ts
@@ -1,4 +1,4 @@
-import type { Any } from "src/common/types";
+import type { Any } from "./types";
 
 export const trace = <Fn extends Any.Function>(fn: Fn) => {
   function newFn(...args: Parameters<Fn>) {
@@ -6,8 +6,18 @@ export const trace = <Fn extends Any.Function>(fn: Fn) => {
     console.time(tag);
     // @ts-expect-error TS2683
     const result = fn.apply(this, args);
-    console.timeEnd(tag);
-    return result;
+
+    // non-promises
+    if (!result.then) {
+      console.timeEnd(tag);
+      return result;
+    }
+
+    // promises
+    return result.then((r: unknown) => {
+      console.timeEnd(tag);
+      return r;
+    });
   }
 
   // Copy properties to new function

--- a/test/trace.test.ts
+++ b/test/trace.test.ts
@@ -32,3 +32,38 @@ test("maintains function properties", async (t) => {
   t.is(tracedIncBy.length, 2);
   t.is(tracedIncBy.prototype.foo, "bar");
 });
+
+test("returns correct value for sync functions", async (t) => {
+  function inc(x: number) {
+    return x + 1;
+  }
+
+  const tracedInc = trace(inc);
+
+  t.is(tracedInc(2), 3);
+});
+
+test("returns correct value for async functions", async (t) => {
+  async function inc(x: number) {
+    return new Promise<number>((resolve) => {
+      setTimeout(() => {
+        resolve(x + 1);
+      }, 1000);
+    });
+  }
+
+  const tracedInc = trace(inc);
+
+  // with await
+  t.is(await tracedInc(2), 3);
+
+  // with chaining
+  await tracedInc(2)
+    .then((x) => {
+      t.is(x, 3);
+      return inc(x);
+    })
+    .then((x) => {
+      t.is(x, 4);
+    });
+});


### PR DESCRIPTION
# Overview
This PR adds support for retry with different delay strategies such as exponential backoff or linear and for any custom strategy as well.

Delay functions are called with the attempt number.


```ts
import { retry, delayStrategy } from 'ts-wrappers'

const myFn = async () => {} // Retry functions have to be async
const myFnWithRetry = retry(5, delayStrategy.exponential())(myFn)

myFnWithRetry()
```